### PR TITLE
Add optional delete account button

### DIFF
--- a/SmartYard.xcodeproj/project.pbxproj
+++ b/SmartYard.xcodeproj/project.pbxproj
@@ -440,6 +440,7 @@
 		84F840D623E07DA5008DBE50 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F840D523E07DA5008DBE50 /* AppDelegate.swift */; };
 		84F840DD23E07DA5008DBE50 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84F840DC23E07DA5008DBE50 /* Assets.xcassets */; };
 		84F840E023E07DA5008DBE50 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 84F840DE23E07DA5008DBE50 /* LaunchScreen.storyboard */; };
+		866537D12C9AF3AA00753234 /* DeleteAccountRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866537D02C9AF3AA00753234 /* DeleteAccountRequest.swift */; };
 		C00F843EA1FB620BA1AA26C3 /* Pods_SmartYardWidget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BD6C4E691C3E6B068AC5708 /* Pods_SmartYardWidget.framework */; };
 		E9004C6023FABF2200B59976 /* IntercomTemporaryAccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9004C5E23FABF2200B59976 /* IntercomTemporaryAccessView.swift */; };
 		E917244B2410E2B300F2B810 /* SmartYardSearchTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = E917244A2410E2B300F2B810 /* SmartYardSearchTextField.swift */; };
@@ -1383,6 +1384,7 @@
 		84F840D523E07DA5008DBE50 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		84F840DC23E07DA5008DBE50 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		84F840DF23E07DA5008DBE50 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		866537D02C9AF3AA00753234 /* DeleteAccountRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountRequest.swift; sourceTree = "<group>"; };
 		BB0746908CEB376CAF4F47CA /* Pods_SmartYard.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SmartYard.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD7CD300677709F4E9C24DD9 /* Pods-SmartYardIntents.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SmartYardIntents.debug.xcconfig"; path = "Target Support Files/Pods-SmartYardIntents/Pods-SmartYardIntents.debug.xcconfig"; sourceTree = "<group>"; };
 		C11A147380472F4F27E6BEB5 /* Pods-SmartYard.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SmartYard.debug.xcconfig"; path = "Target Support Files/Pods-SmartYard/Pods-SmartYard.debug.xcconfig"; sourceTree = "<group>"; };
@@ -3576,6 +3578,14 @@
 			path = SmartYard;
 			sourceTree = "<group>";
 		};
+		866537D22C9AF3CF00753234 /* DeleteAccount */ = {
+			isa = PBXGroup;
+			children = (
+				866537D02C9AF3AA00753234 /* DeleteAccountRequest.swift */,
+			);
+			path = DeleteAccount;
+			sourceTree = "<group>";
+		};
 		9597597AA6C1CAECCA7D92F7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -3793,6 +3803,7 @@
 				E92EFBE4242A247F003AF7FE /* Restore */,
 				E92EFB83242A22F2003AF7FE /* GetPaymentsList */,
 				84AADD222431FA8A0056994A /* Notification */,
+				866537D22C9AF3CF00753234 /* DeleteAccount */,
 			);
 			path = User;
 			sourceTree = "<group>";
@@ -5212,6 +5223,7 @@
 				E92EFBE3242A22F2003AF7FE /* BaseRequestRetrier.swift in Sources */,
 				E94B6C8D2407F8E200FD9F65 /* IssueTypes.swift in Sources */,
 				3A200B0B27297EAC0022A0EC /* PeriodPicker.swift in Sources */,
+				866537D12C9AF3AA00753234 /* DeleteAccountRequest.swift in Sources */,
 				843FB12024BF3BC20060ACEC /* ChatReadedRequest.swift in Sources */,
 				3A1F213826DF8F4F005FDB82 /* ModalViewController.swift in Sources */,
 				E92EFBA9242A22F2003AF7FE /* APIIssueConnect.swift in Sources */,

--- a/SmartYard/Constants.swift
+++ b/SmartYard/Constants.swift
@@ -27,5 +27,6 @@ enum Constants {
     static let defaultPhonePrefix = "7"
     static let defaultPhonePattern = "(###) ###-##-##"
     static let defaultTimeZone = "Europe/Moscow"
+    static let showDeleteAccountButton = false
     
 }

--- a/SmartYard/Flows/MainTabBar/Settings/CommonSettings/View/Base.lproj/CommonSettingsViewController.xib
+++ b/SmartYard/Flows/MainTabBar/Settings/CommonSettings/View/Base.lproj/CommonSettingsViewController.xib
@@ -35,6 +35,8 @@
                 <outlet property="camerasHeaderArrowImageView" destination="58e-Xm-b5i" id="FrI-hc-cuE"/>
                 <outlet property="collapsedCallsBottomConstraint" destination="lg7-cU-7OK" id="dMJ-ze-set"/>
                 <outlet property="collapsedNotificationsBottomConstraint" destination="N57-Dx-SOM" id="ifc-tR-pnm"/>
+                <outlet property="deleteAccountBottomConstraint" destination="Sz1-Xk-Brm" id="fpf-SY-Arf"/>
+                <outlet property="deleteAccountButton" destination="duv-cH-I0h" id="Sha-hf-N7Y"/>
                 <outlet property="editNameButton" destination="Y3c-N0-v2y" id="G3g-1k-ghT"/>
                 <outlet property="enableListContainerView" destination="FUg-hI-JbN" id="pje-U9-f3O"/>
                 <outlet property="enableListSwitch" destination="ugu-Bn-1wd" id="D9h-eb-zi4"/>
@@ -652,13 +654,29 @@
                                                         </userDefinedRuntimeAttribute>
                                                     </userDefinedRuntimeAttributes>
                                                 </button>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="duv-cH-I0h">
+                                                    <rect key="frame" x="0.0" y="726.5" width="382" height="56"/>
+                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="56" id="Wsb-Zo-kuR"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="18"/>
+                                                    <inset key="contentEdgeInsets" minX="24" minY="0.0" maxX="24" maxY="0.0"/>
+                                                    <state key="normal" title="Удалить аккаунт">
+                                                        <color key="titleColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </state>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="layerCornerRadius">
+                                                            <real key="value" value="12"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </button>
                                             </subviews>
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
                                                 <constraint firstItem="3WQ-4A-fRg" firstAttribute="top" secondItem="Rja-ay-B0n" secondAttribute="bottom" constant="8" id="1Am-s6-a8T"/>
                                                 <constraint firstItem="lGe-ZA-fd6" firstAttribute="leading" secondItem="OuL-ZB-YLW" secondAttribute="leading" id="2oj-G1-MVx"/>
                                                 <constraint firstItem="3WQ-4A-fRg" firstAttribute="leading" secondItem="OuL-ZB-YLW" secondAttribute="leading" id="6K6-wi-jYx"/>
-                                                <constraint firstAttribute="bottom" secondItem="lGe-ZA-fd6" secondAttribute="bottom" id="9pY-Yv-KLH"/>
                                                 <constraint firstItem="Rja-ay-B0n" firstAttribute="top" secondItem="OuL-ZB-YLW" secondAttribute="top" constant="260" id="C4i-ZV-euq"/>
                                                 <constraint firstAttribute="trailing" secondItem="bff-6l-Glm" secondAttribute="trailing" id="EVj-zz-2Kh"/>
                                                 <constraint firstItem="bff-6l-Glm" firstAttribute="leading" secondItem="OuL-ZB-YLW" secondAttribute="leading" id="EgX-SC-ZzF"/>
@@ -666,8 +684,13 @@
                                                 <constraint firstAttribute="trailing" secondItem="3WQ-4A-fRg" secondAttribute="trailing" id="GTl-Yx-itR"/>
                                                 <constraint firstItem="bff-6l-Glm" firstAttribute="top" secondItem="3WQ-4A-fRg" secondAttribute="bottom" constant="8" id="GWF-UG-PNs"/>
                                                 <constraint firstAttribute="trailing" secondItem="Rja-ay-B0n" secondAttribute="trailing" id="GsU-wm-tCl"/>
+                                                <constraint firstItem="duv-cH-I0h" firstAttribute="top" secondItem="lGe-ZA-fd6" secondAttribute="bottom" constant="8" id="Ous-0d-xRh"/>
                                                 <constraint firstAttribute="trailing" secondItem="lGe-ZA-fd6" secondAttribute="trailing" id="P1D-bT-fXU"/>
+                                                <constraint firstAttribute="bottom" secondItem="duv-cH-I0h" secondAttribute="bottom" id="Sz1-Xk-Brm"/>
                                                 <constraint firstItem="Rja-ay-B0n" firstAttribute="leading" secondItem="OuL-ZB-YLW" secondAttribute="leading" id="T16-Ib-v1T"/>
+                                                <constraint firstAttribute="trailing" secondItem="duv-cH-I0h" secondAttribute="trailing" id="f56-a2-Rdh"/>
+                                                <constraint firstItem="duv-cH-I0h" firstAttribute="leading" secondItem="OuL-ZB-YLW" secondAttribute="leading" id="hBg-Ri-QLy"/>
+                                                <constraint firstAttribute="bottom" secondItem="lGe-ZA-fd6" secondAttribute="bottom" priority="900" id="hrN-Vw-Zv0"/>
                                                 <constraint firstItem="Rja-ay-B0n" firstAttribute="top" secondItem="Z39-nu-2Sg" secondAttribute="bottom" constant="8" id="kpf-w6-ZT2"/>
                                                 <constraint firstAttribute="trailing" secondItem="Z39-nu-2Sg" secondAttribute="trailing" id="pTI-v8-Xc6"/>
                                                 <constraint firstItem="Z39-nu-2Sg" firstAttribute="leading" secondItem="OuL-ZB-YLW" secondAttribute="leading" id="quF-Wh-U62"/>

--- a/SmartYard/Flows/MainTabBar/Settings/CommonSettings/View/CommonSettingsViewController.swift
+++ b/SmartYard/Flows/MainTabBar/Settings/CommonSettings/View/CommonSettingsViewController.swift
@@ -62,6 +62,9 @@ class CommonSettingsViewController: BaseViewController, LoaderPresentable {
     @IBOutlet private var expandedCamerasBottomConstaint: NSLayoutConstraint!
     
     @IBOutlet private weak var logoutButton: UIButton!
+    @IBOutlet private weak var deleteAccountButton: UIButton!
+    
+    @IBOutlet private var deleteAccountBottomConstraint: NSLayoutConstraint!
     
     private let viewModel: CommonSettingsViewModel
     
@@ -117,6 +120,9 @@ class CommonSettingsViewController: BaseViewController, LoaderPresentable {
         logoutButton.layerBorderWidth = 1
         logoutButton.layerBorderColor = UIColor.SmartYard.grayBorder
         
+        deleteAccountButton.layerBorderWidth = 1
+        deleteAccountButton.layerBorderColor = UIColor.SmartYard.grayBorder
+        
         let notificationsTapGesture = UITapGestureRecognizer()
         notificationsHeader.addGestureRecognizer(notificationsTapGesture)
         
@@ -164,6 +170,11 @@ class CommonSettingsViewController: BaseViewController, LoaderPresentable {
         
         enableListContainerView.addGestureRecognizer(enableListTapGesture)
         enableListSwitch.isUserInteractionEnabled = false
+        
+        if !Constants.showDeleteAccountButton {
+            deleteAccountButton.isHidden = true
+            deleteAccountBottomConstraint.isActive = false
+        }
     }
     
     private func toggleSection(
@@ -230,6 +241,7 @@ class CommonSettingsViewController: BaseViewController, LoaderPresentable {
             speakerTrigger: speakerTapGesture.rx.event.asDriver().mapToVoid(),
             enableListTrigger: enableListTapGesture.rx.event.asDriver().mapToVoid(),
             logoutTrigger: logoutButton.rx.tap.asDriver(),
+            deleteAccountTrigger: deleteAccountButton.rx.tap.asDriver(),
             callKitHintTrigger: callkitQuestionMark.rx.tap.asDriver()
         )
         

--- a/SmartYard/Flows/MainTabBar/Settings/CommonSettings/View/bg.lproj/CommonSettingsViewController.strings
+++ b/SmartYard/Flows/MainTabBar/Settings/CommonSettings/View/bg.lproj/CommonSettingsViewController.strings
@@ -40,3 +40,6 @@
 
 /* Class = "UILabel"; text = "Показать на карте"; ObjectID = "mLP-oQ-Prc"; */
 "mLP-oQ-Prc.text" = "Покажи на картата";
+
+/* Class = "UIButton"; normalTitle = "Удалить аккаунт"; ObjectID = "duv-cH-I0h"; */
+"duv-cH-I0h.normalTitle" = "Изтриване на акаунт";

--- a/SmartYard/Flows/MainTabBar/Settings/CommonSettings/View/en.lproj/CommonSettingsViewController.strings
+++ b/SmartYard/Flows/MainTabBar/Settings/CommonSettings/View/en.lproj/CommonSettingsViewController.strings
@@ -40,3 +40,5 @@ gets close to zero";
 /* Class = "UILabel"; text = "Показать на карте"; ObjectID = "mLP-oQ-Prc"; */
 "mLP-oQ-Prc.text" = "Show on map";
 
+/* Class = "UIButton"; normalTitle = "Удалить аккаунт"; ObjectID = "duv-cH-I0h"; */
+"duv-cH-I0h.normalTitle" = "Delete account";

--- a/SmartYard/Flows/MainTabBar/Settings/CommonSettings/View/kk.lproj/CommonSettingsViewController.strings
+++ b/SmartYard/Flows/MainTabBar/Settings/CommonSettings/View/kk.lproj/CommonSettingsViewController.strings
@@ -37,3 +37,6 @@
 
 /* Class = "UILabel"; text = "Показать на карте"; ObjectID = "mLP-oQ-Prc"; */
 "mLP-oQ-Prc.text" = "Картада көрсету";
+
+/* Class = "UIButton"; normalTitle = "Удалить аккаунт"; ObjectID = "duv-cH-I0h"; */
+"duv-cH-I0h.normalTitle" = "Есептік жазбаны жою";

--- a/SmartYard/Flows/MainTabBar/Settings/CommonSettings/View/uz.lproj/CommonSettingsViewController.strings
+++ b/SmartYard/Flows/MainTabBar/Settings/CommonSettings/View/uz.lproj/CommonSettingsViewController.strings
@@ -37,3 +37,6 @@
 
 /* Class = "UILabel"; text = "Показать на карте"; ObjectID = "mLP-oQ-Prc"; */
 "mLP-oQ-Prc.text" = "Xaritada ko'rsatish";
+
+/* Class = "UIButton"; normalTitle = "Удалить аккаунт"; ObjectID = "duv-cH-I0h"; */
+"duv-cH-I0h.normalTitle" = "Hisobni o'chirish";

--- a/SmartYard/Services/APIWrapper/APITarget.swift
+++ b/SmartYard/Services/APIWrapper/APITarget.swift
@@ -61,6 +61,7 @@ enum APITarget {
     case registerPushToken(request: RegisterPushTokenRequest)
     case confirmCode(request: ConfirmCodeRequest)
     case checkPhone(request: CheckPhoneRequest)
+    case deleteAccount(request: DeleteAccountRequest)
     
     case getPaymentsList(request: GetPaymentsListRequest)
     case sendName(request: SendNameRequest)
@@ -152,6 +153,7 @@ extension APITarget: TargetType {
         case .registerPushToken: return "user/registerPushToken"
         case .confirmCode: return "user/confirmCode"
         case .checkPhone: return "user/checkPhone"
+        case .deleteAccount: return "user/deleteAccount"
         
         case .getPaymentsList: return "user/getPaymentsList"
         case .sendName: return "user/sendName"
@@ -241,6 +243,7 @@ extension APITarget: TargetType {
             case .sendName(let request): return (request.accessToken, false)
             case .restore(let request): return (request.accessToken, false)
             case .notification(let request): return (request.accessToken, false)
+            case .deleteAccount(let request): return (request.accessToken, false)
                 
             case .payPrepare(let request): return (request.accessToken, false)
             case .payProcess(let request): return (request.accessToken, false)
@@ -337,6 +340,7 @@ extension APITarget: TargetType {
         case .registerPushToken(let request): return request.requestParameters
         case .confirmCode(let request): return request.requestParameters
         case .checkPhone(let request): return request.requestParameters
+        case .deleteAccount(let request): return request.requestParameters
         
         case .getPaymentsList(let request): return request.requestParameters
         case .sendName(let request): return request.requestParameters

--- a/SmartYard/Services/APIWrapper/Requests/User/APIWrapper+User.swift
+++ b/SmartYard/Services/APIWrapper/Requests/User/APIWrapper+User.swift
@@ -260,4 +260,22 @@ extension APIWrapper {
             .mapAsEmptyDataInitializableResponse()
             .mapToOptional()
     }
+    
+    func deleteAccount() -> Single<Void?> {
+        guard isReachable else {
+            return .error(NSError.APIWrapperError.noConnectionError)
+        }
+
+        guard let accessToken = accessService.accessToken else {
+            return .error(NSError.APIWrapperError.accessTokenMissingError)
+        }
+
+        let request = DeleteAccountRequest(accessToken: accessToken)
+
+        return provider.rx
+            .request(.deleteAccount(request: request))
+            .convertNoConnectionError()
+            .mapAsVoidResponse()
+            .mapToOptional()
+    }
 }

--- a/SmartYard/Services/APIWrapper/Requests/User/DeleteAccount/DeleteAccountRequest.swift
+++ b/SmartYard/Services/APIWrapper/Requests/User/DeleteAccount/DeleteAccountRequest.swift
@@ -1,0 +1,23 @@
+//
+//  DeleteAccountRequest.swift
+//  SmartYard
+//
+//  Created by admin on 30/03/2020.
+//  Copyright © 2021 LanTa. All rights reserved.
+//
+
+import Foundation
+
+struct DeleteAccountRequest {
+    let accessToken: String
+}
+
+extension DeleteAccountRequest {
+    
+    var requestParameters: [String: Any] {
+        var params = [String: Any]()
+
+        return params
+    }
+    
+}

--- a/SmartYard/bg.lproj/Localizable.strings
+++ b/SmartYard/bg.lproj/Localizable.strings
@@ -64,6 +64,8 @@
 "Specify a reason" = "Посочете причина";
 "Exiting the application" = "Излизане от приложението";
 "Are you sure you want to log out of your account?" = "Сигурни ли сте, че искате да излезете от вашия акаунт?";
+"Account deleting" = "Изтриване на акаунт";
+"Are you sure you want to delete your account? All previously added addresses will be deleted" = "Сигурни ли сте, че искате да изтриете акаунта си? Всички добавени преди това адреси ще бъдат изтрити";
 "Number of contract" = "Номер на договор";
 "Address settings" = "Настройки на адреса";
 "Access setting" = "Настройка на достъп";

--- a/SmartYard/en.lproj/Localizable.strings
+++ b/SmartYard/en.lproj/Localizable.strings
@@ -70,6 +70,8 @@
 "Specify a reason" = "Specify a reason";
 "Exiting the application" = "Exiting the application";
 "Are you sure you want to log out of your account?" = "Are you sure you want to log out of your account?";
+"Account deleting" = "Account deleting";
+"Are you sure you want to delete your account? All previously added addresses will be deleted" = "Are you sure you want to delete your account? All previously added addresses will be deleted";
 "Number of contract" = "Number of contract";
 "Address settings" = "Address settings";
 "Access setting" = "Access setting";

--- a/SmartYard/kk.lproj/Localizable.strings
+++ b/SmartYard/kk.lproj/Localizable.strings
@@ -72,6 +72,8 @@
 "Specify a reason" = "Себепті көрсетіңіз";
 "Exiting the application" = "Қолданбадан шығу";
 "Are you sure you want to log out of your account?" = "Сіз сөйлеміңіз келсе, сіз жеке кабинетіңізден шығу керек пе?";
+"Account deleting" = "Есептік жазбаны жою";
+"Are you sure you want to delete your account? All previously added addresses will be deleted" = "Есептік жазбаңызды шынымен жойғыңыз келе ме? Бұрын қосылған барлық мекенжайлар жойылады";
 "Number of contract" = "Договор нөмері";
 "Address settings" = "Мекен-жай параметрлері";
 "Access setting" = "Кіруге рұқсат беру параметрлері";

--- a/SmartYard/ru.lproj/Localizable.strings
+++ b/SmartYard/ru.lproj/Localizable.strings
@@ -71,6 +71,8 @@
 "Specify a reason" = "Укажите причину";
 "Exiting the application" = "Выход из приложения";
 "Are you sure you want to log out of your account?" = "Вы действительно хотите выйти из вашей учетной записи?";
+"Account deleting" = "Удаление учетной записи";
+"Are you sure you want to delete your account? All previously added addresses will be deleted" = "Вы уверены, что хотите удалить свою учетную запись? Все ранее добавленные адреса будут удалены";
 "Number of contract" = "Номер договора";
 "Address settings" = "Настройки адреса";
 "Access setting" = "Управление доступом";

--- a/SmartYard/uz.lproj/Localizable.strings
+++ b/SmartYard/uz.lproj/Localizable.strings
@@ -70,6 +70,8 @@
 "Specify a reason" = "Sababni ko'rsating";
 "Exiting the application" = "Ilovadan chiqish";
 "Are you sure you want to log out of your account?" = "Hisobingizdan chiqishni istaysizmi?";
+"Account deleting" = "Hisobni o'chirish";
+"Are you sure you want to delete your account? All previously added addresses will be deleted" = "Hisobingizni oʻchirib tashlamoqchimisiz? Oldin qo'shilgan barcha manzillar o'chiriladi";
 "Number of contract" = "Shartnoma raqami";
 "Address settings" = "Manzil sozlamalari";
 "Access setting" = "Kirishni boshqarish";


### PR DESCRIPTION
Apple требует реализацию удаления аккаунта в соответствии с Apple guideline 5.1.1 (v)

После недельных переписок, я не смог доказать им, что учетные записи не создаются в приложении. Оказалось проще реализовать удаление. В SmartYard-Server удаляется только номер телефона. После добавления кнопки одобрение прошло мгновенно

Кнопка по умолчанию отключена (SmartYard/Constants.swift). Включение может сэкономить время другим

Сложно поддерживать такие изменения в своей ветке и при этом поддерживать ее свежей