### PR TITLE
close incoming call screen on remote hangup

### DIFF
--- a/SmartYard/Flows/IncomingCall/ViewModel/IncomingCallViewModel.swift
+++ b/SmartYard/Flows/IncomingCall/ViewModel/IncomingCallViewModel.swift
@@ -878,6 +878,18 @@ extension IncomingCallViewModel: LinphoneDelegate {
     
     func onCallStateChanged(lc: Core, call: Call, cstate: Call.State, message: String) {
         Logger.logDebug("CALL STATE: \(cstate)")
+        // the remote side (server / panel) ended or cancelled the call - e.g. an unanswered call timing out -
+        // liblinphone reports .End/.Released/.Error; close the screen, otherwise it stays with dead buttons
+        if cstate == .End || cstate == .Released || cstate == .Error {
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self,
+                      let state = try? self.currentStateSubject.value(),
+                      state.callState != .callFinished else {
+                    return
+                }
+                self.finishCallAndClose()
+            }
+        }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
             self?.callStateIsStreamRunning.onNext(cstate == .StreamsRunning ? true : false)
         }


### PR DESCRIPTION
Если абонент не отвечает на вызов в течение ~30 секунд после его начала, то звонок завершается, но при этом остается окно звонка: все кнопки на месте. Также можно нажать на кнопку "Ответить" и будет отображено, что звонок начался и идет время вызова, но по факту ничего не происходит - связи с домофоном нет.